### PR TITLE
Add Wait at the end of Purge

### DIFF
--- a/install_start_print.sh
+++ b/install_start_print.sh
@@ -257,6 +257,8 @@ gcode:
     #STATUS_CLEANING                                             # Sets SB-LEDs to cleaning-mode
     LINE_PURGE                                                  # KAMP line purge
 
+    M400                                                        # Wait for the Purge moves to finish
+
     M117 Printer goes brrr                                      # Display print starting
     
     #STATUS_PRINTING                                             # Sets SB-LEDs to printing-mode


### PR DESCRIPTION
Add M400 after the Purge instructions so that the "The purge...." remains displayed during the purge as opposed to moving to "Printer goes brrr" while purging.

I have tested an M400 in this position on my own printer, but I have not tested the installation script as modified.